### PR TITLE
Fixes resolving of hosts when using fuel names

### DIFF
--- a/fuel.py
+++ b/fuel.py
@@ -61,6 +61,7 @@ def fuel_inventory():
             'ip': node['ip'],
             'mac': node['mac'],
             'cluster' : cluster_id,
+            'ansible_ssh_host': node['ip']
         }
         inventory['_meta']['hostvars'][hostname] = nodemeta
     return inventory


### PR DESCRIPTION
Before patch ansible was unable to resolve
hosts by the saved name in Fuel. This patch
uses a special variable ansible_ssh_host
and sets it to the admin ip of the specific
host.
