### PR TITLE
Adds new groups: all, node-${nodeid}

### DIFF
--- a/fuel.py
+++ b/fuel.py
@@ -71,7 +71,6 @@ def fuel_inventory():
             'ansible_ssh_host': node['ip']
         }
         inventory["node-{}".format(node['id'])].append(hostname)
-        inventory["all"].append("node-{}".format(node['id']))
         inventory['_meta']['hostvars'][hostname] = nodemeta
     return inventory
 

--- a/fuel.py
+++ b/fuel.py
@@ -70,6 +70,8 @@ def fuel_inventory():
             'cluster' : cluster_id,
             'ansible_ssh_host': node['ip']
         }
+        inventory["node-{}".format(node['id'])].append(hostname)
+        inventory["all"].append("node-{}".format(node['id']))
         inventory['_meta']['hostvars'][hostname] = nodemeta
     return inventory
 


### PR DESCRIPTION
 `node-${nodeid}` group is created for all hosts.  Fuel convention is to configure
  node-${nodeid} hostname for physical nodes, so it's convenient to use same aliases for ansible invocations as well
 `all` group is a list of node-${nodeid} aliases for all hosts
